### PR TITLE
Replace deprecated each with foreach

### DIFF
--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }
@@ -84,7 +84,6 @@ class Zend_Cache_Backend
             if (array_key_exists($name, $this->_directives)) {
                 $this->_directives[$name] = $value;
             }
-
         }
 
         $this->_loggerSanity();


### PR DESCRIPTION
Since `each` is deprecated in 7.2, and this is the only occurrence (everywhere else `foreach` is used).